### PR TITLE
Add presets/helm/reis0@patches submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "presets/helm/patches@reis0"]
+	path = presets/helm/patches@reis0
+	url = https://gitlab.com/REIS0/reis0-patches


### PR DESCRIPTION
Adding my patches for the helm synthesizer, since I store them in a separate repo I've decided to use the git submodule system to make it easier to update. But if it's preferred to not use this and just add the files I can change it but it would have the problem that I need to remember to make another pull request for new ones (which I'm not confident I will).

If the submodule stays I can change de commando to download in the README to address this. 